### PR TITLE
Added support for images from the web in taxon/characters.

### DIFF
--- a/tombio/kbchecks.js
+++ b/tombio/kbchecks.js
@@ -506,7 +506,7 @@
             }
         })
 
-        tbv.media.filter(function (m) { return (m.Type == "image-local") }).forEach(function (m) {
+        tbv.media.filter(function (m) { return (m.Type == "image-local" || m.Type == "image-web") }).forEach(function (m) {
 
             if (m.Character != "" && charactersFromCharactersTab.indexOf(m.Character) == -1) {
                 //A character on the media tab does not appear on the characters tab

--- a/tombio/keyinput.js
+++ b/tombio/keyinput.js
@@ -570,7 +570,7 @@
 
         //Retrieve collection of media image rows for this character and sort by priority.
         var charImagesFull = tbv.media.filter(function (m) {
-            if (m.Type == "image-local" && m.Character == character) {
+            if ((m.Type == "image-local" || m.Type == "image-web") && m.Character == character) {
                 return true;
             }
         }).sort(function (a, b) {
@@ -691,7 +691,7 @@
         //Help images for character (not necessarily illustrating particular states)
         var charImages = tbv.media.filter(function (m) {
             //Only return images for matching character if no state value is set
-            if (m.Type == "image-local" && m.Character == character && !m.State) {
+            if ((m.Type == "image-local" || m.Type == "image-web") && m.Character == character && !m.State) {
                 //Check UseFor field - it id doesn't exist (backward compatibility for older KBs) 
                 //or exists and empty then allow image.
                 //Otherwise ensure that "full" is amongst comma separated list.
@@ -748,7 +748,7 @@
             //Help images for character states
             var charImages = tbv.media.filter(function (m) {
                 //Only return images for matching character if no state value is set
-                if (m.Type == "image-local" && m.Character == character && m.State == charState.CharacterState) return true;
+                if ((m.Type == "image-local" || m.Type == "image-web") && m.Character == character && m.State == charState.CharacterState) return true;
             }).sort(function (a, b) {
                 return Number(a.Priority) - Number(b.Priority)
             });

--- a/tombio/tombiovis.js
+++ b/tombio/tombiovis.js
@@ -710,7 +710,7 @@
         }
         //Are there any help images on media tab?
         var charImages = tbv.media.filter(function (m) {
-            if (m.Type == "image-local" && m.Character == character) {
+            if ((m.Type == "image-local" || m.Type == "image-web") && m.Character == character) {
                 return true;
             }
         });
@@ -991,7 +991,7 @@
         divNotFound.append("<p>If a file cannot be found but you think it is present, check the case carefully. The case used to name the file must match exactly the case used in the knowledge-base. For example, a file with extension '.JPG' will not match the same filename in the knowledge-base if it is written there as '.jpg'.</p>");
         divFound.append("<h3>Found</h3>");
 
-        tbv.media.filter(function (m) { return (m.Type == "image-local" || m.Type == "html-local") }).forEach(function (m) {
+        tbv.media.filter(function (m) { return (m.Type == "image-local" || m.Type == "html-local" || m.Type == "image-web") }).forEach(function (m) {
 
             //Check that the image files actually exist
             mediaFileExists(m.URI,

--- a/tombio/visP.js
+++ b/tombio/visP.js
@@ -670,7 +670,7 @@
     visP.getTaxonImages = function (taxon) {
         //Return list of all media images for taxon, sorted by priority
         var taxonImages = tbv.media.filter(function (m) {
-            if (m.Taxon == taxon && m.Type == "image-local") return true;
+            if (m.Taxon == taxon && (m.Type == "image-local" || m.Type == "image-web")) return true;
         }).sort(function (a, b) {
             return Number(a.Priority) - Number(b.Priority)
         });
@@ -680,7 +680,7 @@
     visP.getTaxonTipImage = function (taxon) {
         //Return list of all media images for taxon, sorted by priority
         var taxonImages = tbv.media.filter(function (m) {
-            if (m.Taxon == taxon && m.Type == "image-local") {
+            if (m.Taxon == taxon && (m.Type == "image-local" || m.Type == "image-web")) {
                 //Check UseFor field - it id doesn't exist or exists and empty then allow image
                 //Otherwise ensure that "tip" is amongst comma separated list
                 if (!m.UseFor) {


### PR DESCRIPTION
Pull request for  #17.

In the Excel file media sheet, you can now specify any HTTP/HTTPS URL in the URI column if you specify "image-web" in the Type column. This works for both taxon images and character images.

I was not able to minify the debug JavaScript files as there are no task runner nor bundling tool referenced in the repository. There are no instructions about that either in the coders documentation PDF file. I noticed you have not commit the minified files for months. I recommend using npm with a package.json file in the repository. You could have a npm build task that would minify the files with gulp and a minification plugin in an output directory that would be ignored by git. I could help you with that setup if you would like.